### PR TITLE
Tar stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@
 *.exe
 *.out
 *.app
+
+# CLion project directory
+/.idea

--- a/include/tar/tar.hpp
+++ b/include/tar/tar.hpp
@@ -389,7 +389,11 @@ namespace tar{
 
 	private:
 		bool process_file(){
-			if (is_.fail()) {
+			if (is_.bad()) {
+				Logger::error("I/O error", filename_);
+				return false;
+			} else if (is_.fail()) {
+				Logger::error("Stream error", filename_);
 				return false;
 			}
 
@@ -410,13 +414,16 @@ namespace tar{
 			if (is_.eof()) {
 				Logger::trace("Read " + std::to_string(actual_file_size_) + " bytes", filename_);
 				if (actual_file_size_ != expected_file_size_){
-					throw std::runtime_error(
-						"Tar: Read file size " + std::to_string(actual_file_size_) + " " +
-						"is different than expected " + std::to_string(expected_file_size_) + ": " +
-						filename_
-					);
+					Logger::error("Read file size " + std::to_string(actual_file_size_) + " " +
+								  "is different than expected " + std::to_string(expected_file_size_), filename_);
+					is_.setstate(std::ios_base::failbit); // logical error
+					return false;
 				}
+			} else if (is_.bad()) {
+				Logger::error("I/O error", filename_);
+				return false;
 			} else if (is_.fail()) {
+				Logger::error("Stream error", filename_);
 				return false;
 			}
 

--- a/include/tar/tar.hpp
+++ b/include/tar/tar.hpp
@@ -346,7 +346,9 @@ namespace tar{
 		std::ifstream is_;
 		std::string filename_;
 		std::size_t padding_bytes_{0};
+		// expected size of the file written to the tar header
 		std::size_t expected_file_size_{0};
+		// how many bytes we already read from input
 		std::size_t actual_file_size_{0};
 
 		// Not owning reference to parent stream, used for propagating errors
@@ -389,6 +391,7 @@ namespace tar{
 
 	private:
 		bool process_file(){
+			assert(actual_file_size_ <= expected_file_size_);
 			if (is_.bad()) {
 				Logger::error("I/O error", filename_);
 				return false;
@@ -404,7 +407,7 @@ namespace tar{
 			if (actual_file_size_ > expected_file_size_){
 				// truncate to expected size
 				size_t diff = actual_file_size_ - expected_file_size_;
-				assert(diff < size);
+				assert(diff <= size);
 				size -= diff;
 				actual_file_size_ = expected_file_size_;
 				Logger::warning("File size increased during read, truncate to " + std::to_string(expected_file_size_), filename_);

--- a/include/tar/tar.hpp
+++ b/include/tar/tar.hpp
@@ -191,7 +191,7 @@ namespace tar{
 
 			if(name.size() >= 100){
 				throw std::runtime_error(
-					"Tar: filename larger than 99 charakters"
+					"Tar: filename larger than 99 characters"
 				);
 			}
 

--- a/include/tar/tar.hpp
+++ b/include/tar/tar.hpp
@@ -365,7 +365,7 @@ namespace tar{
 
 	public:
 		int underflow() {
-			if (this->gptr() == this->egptr()) {
+			while (this->gptr() == this->egptr()) {
 				if (is_.eof()){ // end of current file
 					if (end_record_bytes_ > 0) { // record padding
 						assert(end_record_bytes_ <= buffer_.size());
@@ -374,6 +374,7 @@ namespace tar{
 						end_record_bytes_ = 0;
 					} else if (files_.empty()) { // tar eof
 						upper_.setstate(std::istream::eofbit);
+						return std::char_traits<char>::eof();
 					} else { // next file
 						next_file();
 					}
@@ -416,9 +417,8 @@ namespace tar{
 					this->setg(this->buffer_.data(), this->buffer_.data(), this->buffer_.data() + size);
 				}
 			}
-			return this->gptr() == this->egptr()
-				   ? std::char_traits<char>::eof()
-				   : std::char_traits<char>::to_int_type(*this->gptr());
+			assert(this->gptr() != this->egptr());
+			return std::char_traits<char>::to_int_type(*this->gptr());
 		}
 
 	private:


### PR DESCRIPTION
Hi. 

In our project we need to read multiple files from filesystem using single stream (`std::istream`). For that reason, I created new class `tar_stream` that makes it possible...

Expected usage:
```
struct TarLogger {
    static void error(const std::string_view &msg, const std::string_view &file){
        std::cerr << "Tar: " << msg << ": " << file << std::endl;
    }

    static void warning(const std::string_view &msg, const std::string_view &file){
        std::cerr << "Tar: " << msg << ": " << file << std::endl;
    }

    static void trace(const std::string_view &msg, const std::string_view &file){
        std::cerr << "Tar: " << msg << ": " << file << std::endl;
    }
};

struct Fs {
    static size_t file_size(const std::string &file) {
      return boost::filesystem::file_size(file);
    }
};

std::set<std::string> files = ... // prepare list of files
tar::tar_stream<TarLogger,Fs> tarStream(files);

// work with tarStream as usual std::istream
```
